### PR TITLE
Change caro board drawer from using text to image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,7 +85,7 @@ ipython_config.py
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:
-# .python-version
+.python-version
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
@@ -140,3 +140,6 @@ cython_debug/
 .env
 
 .idea
+
+# vscode environments
+.vscode

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ emoji==1.2.0
 emojis==0.6.0
 idna==2.10
 multidict==5.1.0
+opencv-python
 pycoingecko==2.2.0
 python-dotenv==0.18.0
 requests==2.25.1

--- a/src/model/caro_board.py
+++ b/src/model/caro_board.py
@@ -18,6 +18,7 @@ class CaroBoard:
     board = None
     victory = None
     block_rule = None
+    board_image = None
 
     def __init__(self, player_1, player_2, width, height, point_to_win, block_rule):
         self.match_id = generate()
@@ -33,6 +34,7 @@ class CaroBoard:
         self.board = np.full((height, width), self.blank_character)
         self.block_rule = block_rule
         self.turns = 0
+        self.board_image = None
 
     def is_first_player(self):
         if self.current_player_turn == self.first_player:

--- a/src/utils/caro_game.py
+++ b/src/utils/caro_game.py
@@ -128,11 +128,11 @@ class CaroGame:
         return None
 
     async def announce_turn(self, message, caro_game):
-        await message.channel.send("```CSS\n{}```".format(self.engine.get_board_drawer(caro_game)))
+        await message.channel.send(file=self.engine.get_board_drawer(caro_game))
         await self.send_message(message, "player_turn", caro_game.current_player_turn)
 
     async def announce_turn_with_info(self, message, caro_game):
-        await message.channel.send("```CSS\n{}```".format(self.engine.get_board_drawer(caro_game)))
+        await message.channel.send(file=self.engine.get_board_drawer(caro_game))
         await self.send_message(message, "board_info",
                                 caro_game.match_id,
                                 caro_game.width,


### PR DESCRIPTION
### Changes
- Added opencv dependency
- Changed caro board drawer from using text to image
  - Caro board now store board's image as 1 attribute
  - `get_board_drawer` now only encode board's image as `discord.File`
  - *(new)* `draw_new_board` draws new board according to `CaroBoard` configuration
  - *(new)* `draw_new_turn` draws new turn based on position and player's turn